### PR TITLE
#80 added support for escaping comma and pipe control characters

### DIFF
--- a/Sieve/Models/FilterTerm.cs
+++ b/Sieve/Models/FilterTerm.cs
@@ -9,6 +9,7 @@ namespace Sieve.Models
         public FilterTerm() { }
 
         private const string EscapedPipePattern = @"(?<!($|[^\\])(\\\\)*?\\)\|";
+        private const string PipeToEscape = @"\|";
 
         private static readonly string[] Operators = new string[] {
                     "!@=*",
@@ -36,7 +37,11 @@ namespace Sieve.Models
                 var filterSplits = value.Split(Operators, StringSplitOptions.RemoveEmptyEntries)
                     .Select(t => t.Trim()).ToArray();
                 Names = Regex.Split(filterSplits[0], EscapedPipePattern).Select(t => t.Trim()).ToArray();
-                Values = filterSplits.Length > 1 ? Regex.Split(filterSplits[1], EscapedPipePattern).Select(t => t.Trim()).ToArray() : null;
+                Values = filterSplits.Length > 1
+                    ? Regex.Split(filterSplits[1], EscapedPipePattern)
+                        .Select(t => t.Replace(PipeToEscape, "|").Trim())
+                        .ToArray()
+                    : null;
                 Operator = Array.Find(Operators, o => value.Contains(o)) ?? "==";
                 OperatorParsed = GetOperatorParsed(Operator);
                 OperatorIsCaseInsensitive = Operator.EndsWith("*");
@@ -90,6 +95,5 @@ namespace Sieve.Models
                 && Values.SequenceEqual(other.Values)
                 && Operator == other.Operator;
         }
-
     }
 }

--- a/Sieve/Models/SieveModel.cs
+++ b/Sieve/Models/SieveModel.cs
@@ -14,6 +14,7 @@ namespace Sieve.Models
         where TSortTerm : ISortTerm, new()
     {
         private const string EscapedCommaPattern = @"(?<!($|[^\\])(\\\\)*?\\),\s*";
+        private const string CommaToEscape = @"\,";
 
         [DataMember]
         public string Filters { get; set; }
@@ -36,10 +37,13 @@ namespace Sieve.Models
                 {
                     if (string.IsNullOrWhiteSpace(filter)) continue;
 
-                    if (filter.StartsWith("("))
+                    var escapedFilter = filter
+                        .Replace(CommaToEscape, ",");
+
+                    if (escapedFilter.StartsWith("("))
                     {
-                        var filterOpAndVal = filter.Substring(filter.LastIndexOf(")") + 1);
-                        var subfilters = filter.Replace(filterOpAndVal, "").Replace("(", "").Replace(")", "");
+                        var filterOpAndVal = escapedFilter.Substring(escapedFilter.LastIndexOf(")") + 1);
+                        var subfilters = escapedFilter.Replace(filterOpAndVal, "").Replace("(", "").Replace(")", "");
                         var filterTerm = new TFilterTerm
                         {
                             Filter = subfilters + filterOpAndVal
@@ -50,7 +54,7 @@ namespace Sieve.Models
                     {
                         var filterTerm = new TFilterTerm
                         {
-                            Filter = filter
+                            Filter = escapedFilter
                         };
                         value.Add(filterTerm);
                     }

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -583,5 +583,61 @@ namespace SieveUnitTests
             Assert.AreEqual(posts[2].Id, 1);
             Assert.AreEqual(posts[3].Id, 0);
         }
+
+        [TestMethod]
+        public void CanFilter_WithEscapeCharacter()
+        {
+            var comments = new List<Comment>
+            {
+                new Comment
+                {
+                    Id = 0,
+                    DateCreated = DateTimeOffset.UtcNow,
+                    Text = "Here is, a comment"
+                },
+                new Comment
+                {
+                    Id = 1,
+                    DateCreated = DateTimeOffset.UtcNow.AddDays(-1),
+                    Text = "Here is, another comment"
+                },
+            }.AsQueryable();
+
+            var model = new SieveModel
+            {
+                Filters = "Text==Here is\\, another comment"
+            };
+
+            var result = _processor.Apply(model, comments);
+            Assert.AreEqual(1, result.Count());
+        }
+
+        [TestMethod]
+        public void OrEscapedPipeValueFilteringWorks()
+        {
+            var comments = new List<Comment>
+            {
+                new Comment
+                {
+                    Id = 0,
+                    DateCreated = DateTimeOffset.UtcNow,
+                    Text = "Here is | a comment"
+                },
+                new Comment
+                {
+                    Id = 1,
+                    DateCreated = DateTimeOffset.UtcNow.AddDays(-1),
+                    Text = "Here is | another comment"
+                },
+            }.AsQueryable();
+
+            var model = new SieveModel()
+            {
+                Filters = "Text==Here is \\| a comment|Here is \\| another comment",
+            };
+
+            var result = _processor.Apply(model, comments);
+            Assert.AreEqual(2, result.Count());
+        }
     }
 }


### PR DESCRIPTION
Using an escaped comma or pipe in a value filter causes Sieve to send the escape character in the filter expression. This PR removes the escape character when the filter is built.